### PR TITLE
Remove amber from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ The budget is public and can be found  [here](./budget.md).
 - Pau Machetti
 - Duy Nguyen
 - Miro Andrin Debrunner
-- Amber Kowalski
 - Gijs de Jong
 
 ## Contact details


### PR DESCRIPTION
amber stepped down from her roles.

Not sure what's up with the last line in the file, i didn't change anything. I used GitHubs online editor, probably changed the line ending or something